### PR TITLE
Add libxcrypt-compat package for psycopg2 compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN chmod -R g=u /etc/passwd
 RUN dnf install -y --setopt=tsflags=nodocs \
                 git \
                 gcc \
+                libxcrypt-compat \
                 python2 \
                 python3 \
                 python2-pip \


### PR DESCRIPTION
A project using the tox container to run Python unit tests on a
Django app for a GitLab CI pipleine has started to encounter
pipeline failures because the image on quay.io has been updated to
a more recent version of the Fedora base image. The app uses the
psycopg2 Python library to connect to a PostgreSQL database, and
the unit tests fail upon loading psycopg2 because of a shared
library object file (libcrypt.so.1) which is no longer included in
the Fedora base system. In Fedora 30, this file can be provided
through the libxcypt-compat package.

Note that the Django app is using the pscyopg2-binary repository
from PyPI; if we were allowing pip to compile the C components of
pscopg2 entirely from scratch, it would have PostgreSQL-related
build requirements.