### PR TITLE
Add libffi-devel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,5 +24,6 @@ RUN dnf install -y --setopt=tsflags=nodocs \
                 krb5-devel \
                 popt-devel \
                 libpq-devel \
+                libffi-devel \
                 graphviz-devel && \
     dnf clean all


### PR DESCRIPTION
This library is need to successfully install ansible-lint in tox.
Specifically the issue is with python package cffi starting from version
1.13.0.