### PR TITLE
Create Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,44 @@
+---
+language: generic
+
+services:
+  - docker
+
+stages:
+  - name: build container
+  - name: sanity check
+  - name: deploy
+    if: branch = master
+
+jobs:
+  include:
+    - stage: build container
+      script:
+        - echo 'Building container...'
+          && export CONTAINER_TAG="${TRAVIS_COMMIT:0:7}"
+          && docker build -t tox:$CONTAINER_TAG --build-arg GIT_COMMIT=$CONTAINER_TAG .
+          && docker images
+          && echo "$DOCKER_PASSWORD" | docker login -u="$DOCKER_USERNAME" --password-stdin quay.io
+          && docker tag tox:$CONTAINER_TAG $DOCKER_REMOTE_REPO:$CONTAINER_TAG
+          && docker push $DOCKER_REMOTE_REPO:$CONTAINER_TAG
+          && echo 'Build succeeded!'
+          && echo '______________________________'
+    - stage: sanity check
+      script:
+        - echo 'Sanity check -- running the container we built in Quay'
+          && export CONTAINER_TAG="${TRAVIS_COMMIT:0:7}"
+          && echo "$DOCKER_PASSWORD" | docker login -u="$DOCKER_USERNAME" --password-stdin quay.io
+          && docker run --rm -it $DOCKER_REMOTE_REPO:$CONTAINER_TAG tox --help
+          && echo 'Sanity check succeeded!'
+          && echo '______________________________'
+    - stage: deploy
+      if: branch = master
+      script:
+        - echo 'Deploying container...'
+          && export CONTAINER_TAG="${TRAVIS_COMMIT:0:7}"
+          && echo "$DOCKER_PASSWORD" | docker login -u="$DOCKER_USERNAME" --password-stdin quay.io
+          && docker pull $DOCKER_REMOTE_REPO:$CONTAINER_TAG
+          && docker tag $DOCKER_REMOTE_REPO:$CONTAINER_TAG $DOCKER_REMOTE_REPO:latest
+          && docker push $DOCKER_REMOTE_REPO:latest
+          && echo 'Deployment succeeded!'
+          && echo '______________________________'

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,12 @@ LABEL maintainer="PnT DevOps Automation - Red Hat, Inc." \
       summary="Image used to run tests by GitLab pipelines." \
       distribution-scope="public"
 
+# hack to permit tagging the docker image with the git hash
+# stolen from:
+# https://blog.scottlowe.org/2017/11/08/how-tag-docker-images-git-commit-information/
+ARG GIT_COMMIT=unspecified
+LABEL git_commit=$GIT_COMMIT
+
 # Rrovide way to add user in entrypoint for openshift runs
 RUN chmod -R g=u /etc/passwd
 
@@ -12,11 +18,8 @@ RUN dnf install -y --setopt=tsflags=nodocs \
                 git \
                 gcc \
                 libxcrypt-compat \
-                python2 \
                 python3 \
-                python2-pip \
                 python3-pip \
-                python2-devel \
                 python3-devel \
                 python3-tox \
                 openldap-devel \
@@ -25,5 +28,5 @@ RUN dnf install -y --setopt=tsflags=nodocs \
                 popt-devel \
                 libpq-devel \
                 libffi-devel \
-                graphviz-devel && \
-    dnf clean all
+                graphviz-devel \
+    && dnf clean all

--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@ Repository on Quay")](https://quay.io/repository/redhat-aqe/tox)
 This is a container repository with tox. It can be used in various test
 pipelines in GitLab for example.
 
+Note. Support for python2 has been dropped
+
 # Usage
 
-# podman run -it quay.io/redhat-aqe/tox /bin/bash
+
+```bash
+podman run -it quay.io/redhat-aqe/tox /bin/bash
+```


### PR DESCRIPTION
This change sets up automatic rebuilds using Travis and storage of this container into Quay.
This change may break backward compatibility and current users of the old RedHat AQE Tox container.

Rebuilds are coordinated by Travis CI.

You can see and pull some sample containers in my private space created by Travis:
* https://quay.io/repository/jobava/tox

The change requires the following secrets or env vars:
DOCKER_USERNAME
DOCKER_PASSWORD
DOCKER_REMOTE_REPO (e.g. quay.io/redhat-aqe/tox)
(We will need a robot account set up for the redhat-aqe team)

Obviously, also requires setting up Travis CI for this repo. Moving to Travis for some of our free/open-source projects is the decision to do here.

Along the way I discovered that python2 was dropped from the newest Fedora, so as it stands the redhat-aqe Tox container is no longer buildable. We could go down two routes:
[1] - Build this new container into a different tag, like `:prod` and keep the legacy container into :latest (it will start to fail security scans at some point in the future)
[2] - Break backward compatibility and reuse `:latest` with this new container. Would require notifying users of the old tox to switch to the new one. People still on python2 won't be able to move.

@sochotnicky @Allda @amisstea @fpob @europ @cit1zen @ralphbean 