### PR TITLE
Add hunspell

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,4 +29,6 @@ RUN dnf install -y --setopt=tsflags=nodocs \
                 libpq-devel \
                 libffi-devel \
                 graphviz-devel \
+                hunspell \
+                hunspell-en-US \
     && dnf clean all


### PR DESCRIPTION
Allows use of pylint together with its spell check functionality

Example pylint section using this:

```toml
[testenv:pylint-spelling]
basepython = python3
skip_install = true
deps = -r requirements-dev.txt
       -r requirements.txt
commands = pylint -E source_folder \
                  --disable all --enable spelling \
                  --spelling-dict en_US \
                  --spelling-private-dict-file spelling-word-list.txt \
                  --min-similarity-lines 6 \
                  --max-line-length 88
```

This increases the size of the image from `351MiB` to `374MiB` as seen on quay.io:

https://quay.io/repository/redhat-aqe/tox

(at the time of this PR) This should be the same container as quay.io/redhat-aqe/tox:hunspell