### PR TITLE
Use Fedora31 and add Python2 packages for radas use

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:latest
+FROM registry.fedoraproject.org/fedora:31
 
 LABEL maintainer="PnT DevOps Automation - Red Hat, Inc." \
       vendor="PnT DevOps Automation - Red Hat, Inc." \
@@ -18,14 +18,18 @@ RUN dnf install -y --setopt=tsflags=nodocs \
       git \
       gcc \
       libxcrypt-compat \
+      python2 \
       python3 \
+      python2-pip \
       python3-pip \
+      python2-devel \
       python3-devel \
       python3-tox \
       openldap-devel \
       openssl-devel \
       krb5-devel \
       popt-devel \
+      rpm-devel \
       libpq-devel \
       libffi-devel \
       graphviz-devel \


### PR DESCRIPTION
RADAS is still on Python2. It was using the legacy tagged image but
a new dependency needs to be added. Since the branch that created
legacy no longer exists, we need to create a new branch for the new
dependency.

Note: I DON'T want to merge into master. I want to merge into a branch called "radas", but I'm not able to create branches so could someone with access please create it and change the merge target?