### PR TITLE
Add python2-rpm to the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,7 @@ RUN dnf install -y --setopt=tsflags=nodocs \
       hunspell \
       hunspell-en-US \
       enchant \
+      python2-rpm \
       && dnf clean all
 
 RUN pip3 install awxkit


### PR DESCRIPTION
The package is a dependency for radas and cannot be installed via pip,
see https://pypi.org/project/rpm/.