### PR TITLE
Always update OS packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ LABEL maintainer="PnT DevOps Automation - Red Hat, Inc." \
 ARG GIT_COMMIT=unspecified
 LABEL git_commit=$GIT_COMMIT
 
-RUN dnf install -y --setopt=tsflags=nodocs \
+RUN dnf update -y && dnf install -y --setopt=tsflags=nodocs \
       git \
       gcc \
       libxcrypt-compat \


### PR DESCRIPTION
The fedora base image is not always rebuilt when new versions of its
RPMs are available, even if it's due to a security patch.

Signed-off-by: Luiz Carvalho <lucarval@redhat.com>