### PR TITLE
Including STACS's dependency libarchive-devel install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ RUN dnf install -y --setopt=tsflags=nodocs \
       hunspell \
       hunspell-en-US \
       enchant \
+      libarchive-devel \
       && dnf clean all
 
 RUN pip3 install awxkit


### PR DESCRIPTION
In the current image build, STACS (https://pypi.org/project/stacs/) needs libarchive-devel to be installed in order for it to be successfully installed by pip.

STACS is a YARA powered static credential scanner which suports binary file formats, analysis of nested archives, composable rulesets and ignore lists, and SARIF reporting.

So, I'm adding libarchive-devel to the tox image.