### PR TITLE
add libacl-devel which is required by our project

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,7 @@ RUN dnf update -y && dnf install -y --setopt=tsflags=nodocs \
       hunspell-en-US \
       enchant \
       libarchive-devel \
+      libacl-devel \
       && dnf clean all
 
 RUN pip3 install awxkit


### PR DESCRIPTION
Our internal project requires the following packages for ACL management:
 gcc libacl libacl-devel python3-devel